### PR TITLE
Feature: exclude Rust tests + Hotfix for filename collision

### DIFF
--- a/compare_tool.py
+++ b/compare_tool.py
@@ -224,7 +224,7 @@ def compare_directory_contents(dir1: str, dir2: str, exclude: List[str], method:
     # Files present in both directories
     common_files = files1.keys() & files2.keys()
 
-    for file_name in common_files:
+    for file_name in sorted(common_files):
         file1 = files1[file_name]
         file2 = files2[file_name]
 
@@ -242,7 +242,7 @@ def compare_directory_contents(dir1: str, dir2: str, exclude: List[str], method:
     removed_files = files1.keys() - files2.keys()
     added_files = files2.keys() - files1.keys()
     
-    for file_name in removed_files | added_files:
+    for file_name in sorted(removed_files | added_files):
         lines_difference = 0
         is_removed_file = file_name in removed_files
         file_path = files1[file_name] if is_removed_file else files2[file_name]

--- a/compare_tool.py
+++ b/compare_tool.py
@@ -6,6 +6,7 @@ from typing import List, Tuple
 
 import Levenshtein
 from tabulate import tabulate
+from os.path import relpath
 
 def is_excluded(file_path: str, exclude: List[str]) -> bool:
     """
@@ -217,8 +218,8 @@ def compare_directory_contents(dir1: str, dir2: str, exclude: List[str], method:
     :param method: The comparison method to use ('ratio' or 'distance').
     :return: A list of tuples containing comparison results for each pair of matched files.
     """
-    files1 = {f.name: f for f in Path(dir1).rglob('*') if f.is_file()}
-    files2 = {f.name: f for f in Path(dir2).rglob('*') if f.is_file()}
+    files1 = {relpath(f, dir1): f for f in Path(dir1).rglob('*') if f.is_file()}
+    files2 = {relpath(f, dir2): f for f in Path(dir2).rglob('*') if f.is_file()}
     comparison_results = []
     # Files present in both directories
     common_files = files1.keys() & files2.keys()


### PR DESCRIPTION
### Exclude Rust tests and test modules from comparison
It is pretty common to write Rust tests on the spot, inside the source files. This can greatly distort actual LOC and difference calculation

### Filename collision
If the project has multiple files with the same name but in different directories, the script only compared one of the files with that name. Instead of using direct file names, we can use their relative paths to distinguish one file from another.